### PR TITLE
Load Default Roles on Initialization

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -292,6 +292,103 @@ public class DefaultObjectGenerator implements ServletContextListener {
         }
         return permissions;
     }
+  
+    /**
+     * Loads the default Roles
+     */
+    private void loadDefaultRoles() {
+        try (QueryManager qm = new QueryManager()) {
+            if (!qm.getRoles().isEmpty()) {
+                return;
+            }
+            LOGGER.info("Adding default roles to datastore");
+            LOGGER.debug("Creating role: Project Admin");
+            final Role projectAdmin = qm.createRole("Project Admin", false);
+            LOGGER.debug("Creating role: Project Auditor");
+            final Role projectAuditor = qm.createRole("Project Auditor", false);
+            LOGGER.debug("Creating role: Project Editor");
+            final Role projectEditor = qm.createRole("Project Editor", false);
+            LOGGER.debug("Creating role: Project Viewer");
+            final Role projectViewer = qm.createRole("Project Viewer", true);
+    
+            final List<Permission> fullList = qm.getPermissions();
+    
+            LOGGER.debug("Assigning default permissions to roles");
+            projectAdmin.setPermissions(getProjectAdminPermissions(fullList));
+            projectAuditor.setPermissions(getProjectAuditorPermissions(fullList));
+            projectEditor.setPermissions(getProjectEditorPermissions(fullList));
+            projectViewer.setPermissions(getProjectViewerPermissions(fullList));
+    
+            qm.persist(projectAdmin);
+            qm.persist(projectAuditor);
+            qm.persist(projectEditor);
+            qm.persist(projectViewer);
+        }
+    }
+    
+    private List<Permission> getProjectAdminPermissions(final List<Permission> fullList) {
+        final List<Permission> permissions = new ArrayList<>();
+        for (final Permission permission : fullList) {
+            if (permission.getName().equals(Permissions.PORTFOLIO_MANAGEMENT.name()) ||
+                    permission.getName().equals(Permissions.PORTFOLIO_MANAGEMENT_CREATE.name()) ||
+                    permission.getName().equals(Permissions.PORTFOLIO_MANAGEMENT_READ.name()) ||
+                    permission.getName().equals(Permissions.PORTFOLIO_MANAGEMENT_UPDATE.name()) ||
+                    permission.getName().equals(Permissions.PORTFOLIO_MANAGEMENT_DELETE.name()) ||
+                    permission.getName().equals(Permissions.VULNERABILITY_ANALYSIS.name()) ||
+                    permission.getName().equals(Permissions.VULNERABILITY_ANALYSIS_CREATE.name()) ||
+                    permission.getName().equals(Permissions.VULNERABILITY_ANALYSIS_READ.name()) ||
+                    permission.getName().equals(Permissions.VULNERABILITY_ANALYSIS_UPDATE.name()) ||
+                    permission.getName().equals(Permissions.POLICY_MANAGEMENT.name()) ||
+                    permission.getName().equals(Permissions.POLICY_MANAGEMENT_CREATE.name()) ||
+                    permission.getName().equals(Permissions.POLICY_MANAGEMENT_READ.name()) ||
+                    permission.getName().equals(Permissions.POLICY_MANAGEMENT_UPDATE.name()) ||
+                    permission.getName().equals(Permissions.POLICY_MANAGEMENT_DELETE.name())) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+    
+    private List<Permission> getProjectAuditorPermissions(final List<Permission> fullList) {
+        final List<Permission> permissions = new ArrayList<>();
+        for (final Permission permission : fullList) {
+            if (permission.getName().equals(Permissions.VIEW_PORTFOLIO.name()) ||
+                    permission.getName().equals(Permissions.VIEW_VULNERABILITY.name()) ||
+                    permission.getName().equals(Permissions.VIEW_POLICY_VIOLATION.name()) ||
+                    permission.getName().equals(Permissions.VULNERABILITY_ANALYSIS_READ.name())) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+    
+    private List<Permission> getProjectEditorPermissions(final List<Permission> fullList) {
+        final List<Permission> permissions = new ArrayList<>();
+        for (final Permission permission : fullList) {
+            if (permission.getName().equals(Permissions.BOM_UPLOAD.name()) ||
+                    permission.getName().equals(Permissions.VIEW_PORTFOLIO.name()) ||
+                    permission.getName().equals(Permissions.PORTFOLIO_MANAGEMENT_READ.name()) ||
+                    permission.getName().equals(Permissions.VIEW_VULNERABILITY.name()) ||
+                    permission.getName().equals(Permissions.VULNERABILITY_ANALYSIS_READ.name()) ||
+                    permission.getName().equals(Permissions.PROJECT_CREATION_UPLOAD.name())) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+    
+    private List<Permission> getProjectViewerPermissions(final List<Permission> fullList) {
+        final List<Permission> permissions = new ArrayList<>();
+        for (final Permission permission : fullList) {
+            if (permission.getName().equals(Permissions.VIEW_PORTFOLIO.name()) ||
+                    permission.getName().equals(Permissions.VIEW_VULNERABILITY.name()) ||
+                    permission.getName().equals(Permissions.VIEW_BADGES.name())) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+
 
     /**
      * Loads the default repositories


### PR DESCRIPTION
### Description

This PR adds the functionality to load default roles on initialization of the application. The default roles are created and populated in the database when the application is started.

### Addressed Issue

- Added LoadDefaultRole method to DefaultObjectGenerator class to load default roles on initialization
- Created default roles (Project Admin, Project Editor, Project Viewer, Project Auditor, Portfolio Admin, Portfolio Editor, Portfolio Viewer) in LoadDefaultRole method
- Added permissions for each default role
- Updated executeLocked method in DefaultObjectGenerator class to call LoadDefaultRole method

### Additional Details

None

### Checklist


- [x ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
