### PR TITLE
fix: add role UUID field

### DIFF
--- a/src/main/java/org/dependencytrack/model/Role.java
+++ b/src/main/java/org/dependencytrack/model/Role.java
@@ -61,6 +61,7 @@ import javax.jdo.annotations.Unique;
         @Persistent(name = "name"),
         @Persistent(name = "description"),
         @Persistent(name = "permissions"),
+        @Persistent(name = "uuid"),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Role implements Serializable {

--- a/src/main/java/org/dependencytrack/model/Role.java
+++ b/src/main/java/org/dependencytrack/model/Role.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -34,6 +35,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
+
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
@@ -101,6 +104,12 @@ public class Role implements Serializable {
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Permission> permissions;
 
+    @Persistent(customValueStrategy = "uuid")
+    @Unique(name = "ROLE_UUID_IDX")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
+    @NotNull
+    private UUID uuid;
+
     public long getId() {
         return id;
     }
@@ -143,6 +152,14 @@ public class Role implements Serializable {
         for (var permission : permissions)
             if (!this.permissions.contains(permission))
                 this.permissions.add(permission);
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
     }
 
     @Override

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -678,6 +678,12 @@
             <column name="DESCRIPTION" type="VARCHAR(255)">
                 <constraints nullable="true" />
             </column>
+
+            <column name="UUID" type="UUID">
+                <constraints nullable="false" unique="true"
+                    uniqueConstraintName="ROLE_UUID_IDX"
+                    validateNullable="true" validateUnique="true" />
+            </column>
         </createTable>
 
         <createTable ifNotExists="true" tableName="ROLES_PERMISSIONS">


### PR DESCRIPTION
### Description

Update migrations and model to add `UUID` column and corresponding `uuid` field.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [X] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
