### PR TITLE
Update createRole API to create a new role with permissions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -901,6 +901,10 @@ public class QueryManager extends AlpineQueryManager {
         return getRoleQueryManager().getRoles();
     }
 
+    public Role getRoleByName(String name) {
+        return getRoleQueryManager().getRoleByName(name);
+    }
+
     public Role getRole(String uuid) {
         return getRoleQueryManager().getRole(uuid);
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/RoleQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/RoleQueryManager.java
@@ -33,6 +33,8 @@ import org.dependencytrack.model.ProjectRole;
 import org.dependencytrack.persistence.jdbi.JdbiFactory;
 import org.dependencytrack.persistence.jdbi.RoleDao;
 
+import org.apache.commons.lang3.StringUtils;
+
 import alpine.common.logging.Logger;
 import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
@@ -85,6 +87,17 @@ final class RoleQueryManager extends QueryManager implements IQueryManager {
             query.setOrdering("name asc");
 
         return query.executeList();
+    }
+
+    @Override
+    public Role getRoleByName(final String name) {
+        final String role = StringUtils.lowerCase(StringUtils.trimToNull(name));
+        final Query<Role> query = pm.newQuery(Role.class)
+                .filter("name.toLowerCase().trim() == :name")
+                .setNamedParameters(Map.of("name", role))
+                .range(0, 1);
+
+        return executeAndCloseUnique(query);
     }
 
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateRoleRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateRoleRequest.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+
+package org.dependencytrack.resources.v1.vo;
+
+import java.util.Set;
+
+import org.dependencytrack.auth.Permissions;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import alpine.common.validation.RegexSequence;
+import alpine.server.json.TrimmedStringDeserializer;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateRoleRequest(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) 
+        @NotBlank 
+        @JsonDeserialize(using = TrimmedStringDeserializer.class) 
+        @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS_PLUS, message = "The username may only contain printable characters") 
+        String name,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) 
+        @NotNull 
+        Set<Permissions> permissions) {
+}


### PR DESCRIPTION
### Description

Added the new record type CreateRoleRequest so the createRole API can processes a new role request object with a name and permissions.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
